### PR TITLE
Add meta tag which uses the property instead of name attribute

### DIFF
--- a/rollyourown/seo/__init__.py
+++ b/rollyourown/seo/__init__.py
@@ -2,6 +2,7 @@ VERSION = (1, 0, 0, 'beta', 1)
 __authors__ = ["Will Hardy <django-seo@willhardy.com.au>"]
 
 from rollyourown.seo.base import Metadata, Tag, KeywordTag, MetaTag, Raw, Literal, get_metadata, get_linked_metadata
+from rollyourown.seo.fields import OgMetaTag
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])

--- a/rollyourown/seo/fields.py
+++ b/rollyourown/seo/fields.py
@@ -62,8 +62,8 @@ class MetadataField(object):
                 self.help_text = _('If empty, \"%s\" will be used.') % self.populate_from.value
             elif isinstance(self.populate_from, basestring) and self.populate_from in cls._meta.elements:
                 field = cls._meta.elements[self.populate_from]
-                self.help_text = _('If empty, %s will be used.') % field.verbose_name or field.name  
-            elif isinstance(self.populate_from, basestring) and hasattr(cls, self.populate_from): 
+                self.help_text = _('If empty, %s will be used.') % field.verbose_name or field.name
+            elif isinstance(self.populate_from, basestring) and hasattr(cls, self.populate_from):
                 populate_from = getattr(cls, self.populate_from, None)
                 if callable(populate_from) and hasattr(populate_from, 'short_description'):
                     self.help_text = _('If empty, %s') % populate_from.short_description
@@ -92,11 +92,11 @@ class MetadataField(object):
 class Tag(MetadataField):
     def __init__(self, name=None, head=False, escape_value=True,
                        editable=True, verbose_name=None, valid_tags=None, max_length=511,
-                       choices=None, populate_from=NotSet, field=models.CharField, 
+                       choices=None, populate_from=NotSet, field=models.CharField,
                        field_kwargs=None, help_text=None):
 
         self.escape_value = escape_value
-        if field_kwargs is None: 
+        if field_kwargs is None:
             field_kwargs = {}
         field_kwargs.setdefault('max_length', max_length)
         field_kwargs.setdefault('default', "")
@@ -115,10 +115,10 @@ class Tag(MetadataField):
 VALID_META_NAME = re.compile(r"[A-z][A-z0-9_:.-]*$")
 
 class MetaTag(MetadataField):
-    def __init__(self, name=None, head=True, verbose_name=None, editable=True, 
-                       populate_from=NotSet, valid_tags=None, max_length=511, choices=None, 
+    def __init__(self, name=None, head=True, verbose_name=None, editable=True,
+                       populate_from=NotSet, valid_tags=None, max_length=511, choices=None,
                        field=models.CharField, field_kwargs=None, help_text=None):
-        if field_kwargs is None: 
+        if field_kwargs is None:
             field_kwargs = {}
         field_kwargs.setdefault('max_length', max_length)
         field_kwargs.setdefault('default', "")
@@ -139,16 +139,25 @@ class MetaTag(MetadataField):
         # TODO: HTML/XHTML?
         return u'<meta name="%s" content="%s" />' % (self.name, value)
 
+
+class OgMetaTag(MetaTag):
+    """Renders a meta tag which uses property rather than name, e.g
+        <meta property="og:url" content="http://someurl" />
+    """
+    def render(self, value):
+        return u'<meta property="%s" content="%s" />' % (self.name, value)
+
+
 class KeywordTag(MetaTag):
-    def __init__(self, name=None, head=True, verbose_name=None, editable=True, 
+    def __init__(self, name=None, head=True, verbose_name=None, editable=True,
                        populate_from=NotSet, valid_tags=None, max_length=511, choices=None,
                        field=models.CharField, field_kwargs=None, help_text=None):
         if name is None:
             name = "keywords"
         if valid_tags is None:
             valid_tags = []
-        super(KeywordTag, self).__init__(name, head, verbose_name, editable, 
-                        populate_from, valid_tags, max_length, choices, field, 
+        super(KeywordTag, self).__init__(name, head, verbose_name, editable,
+                        populate_from, valid_tags, max_length, choices, field,
                         field_kwargs, help_text)
 
     def clean(self, value):
@@ -160,10 +169,10 @@ class KeywordTag(MetaTag):
 
 # TODO: if max_length is given, use a CharField and pass it through
 class Raw(MetadataField):
-    def __init__(self, head=True, editable=True, populate_from=NotSet, 
+    def __init__(self, head=True, editable=True, populate_from=NotSet,
                     verbose_name=None, valid_tags=None, choices=None, field=models.TextField,
                     field_kwargs=None, help_text=None):
-        if field_kwargs is None: 
+        if field_kwargs is None:
             field_kwargs = {}
         field_kwargs.setdefault('default', "")
         field_kwargs.setdefault('blank', True)


### PR DESCRIPTION
At the moment the MetaTag metadata field renders 

```
<meta name="somename" content="somecontent" />
```

Unfortunately this doesn't play nice with Facebooks meta tag requirements which need something like:

```
<meta property="somename" content="somevalue" />
```

So I've added a metadata field called `OgMetaTag` which renders as required but is otherwise identical to `MetaTag`.
