### PR TITLE
Handle case where seo_defaultmetadatamodel is created using 'loaddata'. ...

### DIFF
--- a/rollyourown/seo/base.py
+++ b/rollyourown/seo/base.py
@@ -341,7 +341,8 @@ def _update_callback(model_class, sender, instance, created, **kwargs):
         then this shouldn't happen.
         I've held it to be more important to avoid double path entries.
     """
-    create_metadata_instance(model_class, instance)
+    if not kwargs.get('raw'):
+        create_metadata_instance(model_class, instance)
 
 
 def _delete_callback(model_class, sender, instance,  **kwargs):


### PR DESCRIPTION
...The post_save callback should not be active, otherwise there is the potential for unique constraint violations with PostgreSQL DBs.

The test test_fallback_order2 currently fails, but I haven't found a combination of django and django-seo where it doesn't fail, either on Linux or Mac. Also, there are lots of test failures with 1.1.4<= and with >= 1.4, despite the docs saying django-seo is compatible with >= 1.1.
