### PR TITLE
Django 1.7 get_verbose_name

### DIFF
--- a/rollyourown/seo/options.py
+++ b/rollyourown/seo/options.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
+try:
+    from django.db.models.options import get_verbose_name
+except ImportError:
+    from django.utils.text import camel_case_to_spaces as get_verbose_name
 
-from django.db.models.options import get_verbose_name
 from django.db import models
 from django.utils.datastructures import SortedDict
 
@@ -94,7 +97,5 @@ class Options(object):
                 app = models.get_app(model_name)
                 if app:
                     seo_models.extend(models.get_models(app))
-    
+
         self.seo_models = seo_models
-
-


### PR DESCRIPTION
This uses the new utils text package as a way to format a name to the standard format.

In django 1.7 the get_verbose_name util doesn't exist anymore. 
